### PR TITLE
Installtion of zip extensions fails

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,7 +7,7 @@ ENV PHPCENSOR_VERSION=0.22.0
 WORKDIR /var/www/html
 
 RUN apk update && \
-    apk add git nginx openssh postgresql-dev openldap-dev gettext && \
+    apk add git nginx openssh postgresql-dev openldap-dev gettext zlib-dev && \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/bin/composer
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -7,7 +7,7 @@ ENV PHPCENSOR_VERSION=0.22.0
 WORKDIR /var/www/html
 
 RUN apk update && \
-    apk add git openssh postgresql-dev gettext && \
+    apk add git openssh postgresql-dev gettext zlib-dev && \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/bin/composer
 


### PR DESCRIPTION
The build or rather the installation of the zip extensions fails with
```
checking for the location of zlib... configure: error: zip support requires ZLIB. Use --with-zlib-dir=<DIR> to specify prefix where ZLIB include and library are located
```

Adding ```zlib-dev``` to the ```apk add``` section should fix this.